### PR TITLE
Fix watch script for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "sass ./scss:dist/css",
-    "watch": "sass --watch ./scss:dist/css & live-server",
+    "watch": "npm-run-all --parallel watch:sass watch:serve",
+    "watch:sass": "sass --watch ./scss:dist/css",
+    "watch:serve": "live-server .",
     "format": "prettier -w ./js/*.js",
     "lint": "eslint ./js/*.js",
     "lint-fix": "eslint ./js/*.js --cache --fix"


### PR DESCRIPTION
Split watch script into sass and live-server using npm-run-all to avoid issues using windows. 